### PR TITLE
Initial support for python3

### DIFF
--- a/dialog_api/__init__.py
+++ b/dialog_api/__init__.py
@@ -1,0 +1,7 @@
+import six
+PATH_WORKAROUND = six.PY3
+
+if PATH_WORKAROUND:
+    import sys
+    import os
+    sys.path.append(os.path.dirname(__file__))

--- a/dialog_bot_sdk/__init__.py
+++ b/dialog_bot_sdk/__init__.py
@@ -1,1 +1,0 @@
-from internal import peers

--- a/dialog_bot_sdk/bot.py
+++ b/dialog_bot_sdk/bot.py
@@ -1,7 +1,7 @@
 import grpc
-from internal.bot import InternalBot
-from entity_manager import EntityManager
-from messaging import Messaging
+from .internal.bot import InternalBot
+from .entity_manager import EntityManager
+from .messaging import Messaging
 
 
 class DialogBot(object):

--- a/dialog_bot_sdk/entity_manager.py
+++ b/dialog_bot_sdk/entity_manager.py
@@ -1,6 +1,9 @@
-from internal.peers import private_peer, group_peer, peer_hasher
-from dialog_api import peers_pb2, messaging_pb2, miscellaneous_pb2, \
-                       contacts_pb2, search_pb2
+from .internal.peers import private_peer, group_peer, peer_hasher
+import dialog_api
+if dialog_api.PATH_WORKAROUND:
+    import peers_pb2, messaging_pb2, miscellaneous_pb2, contacts_pb2, search_pb2
+else:
+    from dialog_api import peers_pb2, messaging_pb2, miscellaneous_pb2, contacts_pb2, search_pb2
 
 DEFAULT_OPTIMIZATIONS = [
     miscellaneous_pb2.UPDATEOPTIMIZATION_STRIP_ENTITIES,
@@ -38,7 +41,7 @@ class EntityManager(object):
         result = self.peers_to_outpeers.get(hash)
         if result is None:
             req = messaging_pb2.RequestLoadDialogs(
-                min_date = 0L, limit = 1, peers_to_load=[peer],
+                min_date = 0, limit = 1, peers_to_load=[peer],
                 optimizations = DEFAULT_OPTIMIZATIONS
             )
             result = self.internal.messaging.LoadDialogs(req)

--- a/dialog_bot_sdk/internal/bot.py
+++ b/dialog_bot_sdk/internal/bot.py
@@ -1,4 +1,4 @@
-from service import AuthenticatedService
+from .service import AuthenticatedService
 from dialog_api import registration_pb2, registration_pb2_grpc,\
                        sequence_and_updates_pb2_grpc,\
                        authentication_pb2, authentication_pb2_grpc,\
@@ -28,7 +28,7 @@ class InternalBot(object):
                 device_title = self.app_title
             )
         )
-        print registation_response.token
+        print(registation_response.token)
         return registation_response.token
 
     def wrap_sevice(self, stub_func):

--- a/dialog_bot_sdk/internal/peers.py
+++ b/dialog_bot_sdk/internal/peers.py
@@ -1,4 +1,8 @@
-from dialog_api import peers_pb2
+import dialog_api
+if dialog_api.PATH_WORKAROUND:
+    import peers_pb2
+else:
+    from dialog_api import peers_pb2
 
 def private_peer(user_id):
     return peers_pb2.Peer(type=peers_pb2.PEERTYPE_PRIVATE, id=user_id)

--- a/dialog_bot_sdk/internal/service.py
+++ b/dialog_bot_sdk/internal/service.py
@@ -10,7 +10,7 @@ class AuthenticatedService(object):
     def __decorated(self, method_name, method):
         def inner(param):
             auth_token = self.auth_token_func()
-            print 'Calling %s with token=`%s`' % (method_name, auth_token)
+            print('Calling %s with token=`%s`' % (method_name, auth_token))
             if auth_token is not None:
                 metadata = (('x-auth-ticket', auth_token),)
             else:

--- a/dialog_bot_sdk/messaging.py
+++ b/dialog_bot_sdk/messaging.py
@@ -1,4 +1,4 @@
-from service import ManagedService
+from .service import ManagedService
 from dialog_api import messaging_pb2, sequence_and_updates_pb2
 from google.protobuf import empty_pb2
 import time
@@ -23,7 +23,7 @@ class Messaging(ManagedService):
         for update in self.internal.updates.SeqUpdates(empty_pb2.Empty()):
             up = sequence_and_updates_pb2.UpdateSeqUpdate()
             up.ParseFromString(update.update.value)
-            print up.WhichOneof('update'), up.update_header
+            print(up.WhichOneof('update'), up.update_header)
             if up.update_header == 55:
                 #up.WhichOneof('update')
                 callback(up.updateMessage)

--- a/dialog_bot_sdk/peers.py
+++ b/dialog_bot_sdk/peers.py
@@ -1,0 +1,1 @@
+from .internal.peers import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+protobuf
+google-api-python-client
+googleapis-common-protos
+gevent
+grpcio
+grpcio-tools

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ from dialog_bot_sdk import interactive_media
 import time
 
 def on_msg(*params):
-    print 'on msg', params
+    print('on msg', params)
 
 if __name__ == '__main__':
     d = DialogBot.get_insecure_bot("grpc-test.transmit.im:8080", "c1ff5ca4b7e5fa4660c6a730fdcb613e31deafd8")


### PR DESCRIPTION
fix for #2 
Hi, This commit introduces python3 support for this module  
  
Tested on Linux:

Python 2.7.15 -> Works*
Python 3.7.0 -> Works*

 [*] -> I Can't complete my test making sure that everything works because I don't have a valid Token, I can't even access using:
`testuser / testpassword`
(are this credentials outdated?)
  
  
with a valid Token, everything should work correctly,
  
**Error reported from the server:**
`
{"created":"@1539438369.479956615","description":"Error received from peer","file":"src/core/lib/surface/call.cc","file_line":1099,"grpc_message":"Token is not eligible for authorization","grpc_status":3}
`
  

**anyway if you can provide a valid token for my tests, I will do all the additional fixes (if they are required)**