### PR TITLE
DP-9853 dialog_api required version updated to 1.53.0

### DIFF
--- a/setup_unfilled.py
+++ b/setup_unfilled.py
@@ -16,7 +16,7 @@ setuptools.setup(
     license='Apache License 2.0',
     keywords='dialog messenger bot sdk',
     install_requires=[
-        'dialog_api==1.33.0',
+        'dialog_api==1.53.0',
         'protobuf==3.10.0',
         'grpcio==1.24.1',
         'grpcio-tools==1.24.1',


### PR DESCRIPTION
For compatibility with server-sdk 0.1.0 which requires dialog_api==1.53.0.